### PR TITLE
perf: track indices for narrower search

### DIFF
--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -13,54 +13,50 @@ export async function* generate<T>(
 	for await (const chunk of stream) {
 		buffer = Buffer.concat([buffer, chunk], buffer.length + chunk.length);
 		const boundaryIndex = buffer.indexOf(boundary);
+		if (!~boundaryIndex) continue;
 
-		if (isPreamble && !!~boundaryIndex) {
-			isPreamble = false;
+		if (isPreamble) {
 			buffer = buffer.slice(boundaryIndex + boundary.length);
+			isPreamble = false;
 			continue;
 		}
 
-		if (!!~boundaryIndex) {
-			const payload = buffer.slice(0, boundaryIndex);
-			const headerSeparated = payload.indexOf(separator);
-			let data = payload.slice(headerSeparated);
+		const payload = buffer.slice(0, boundaryIndex);
+		const headerSeparated = payload.indexOf(separator);
+		let data = payload.slice(headerSeparated);
 
-			const headers: Map<string, string> = new Map();
-			for (let item of payload
-				.slice(0, headerSeparated)
-				.toString('utf8')
-				.trim()
-				.split(/\r\n/)) {
-				const idx = item.indexOf(':');
-				headers.set(
-					item.slice(0, idx).toLowerCase(),
-					item.slice(idx + 1).trim(),
-				);
-			}
-
-			data = data.slice(data.indexOf(separator) + separator.length);
-
-			if (headers.has('content-length')) {
-				data = data.slice(
-					0,
-					parseInt(headers.get('content-length'), 10),
-				);
-			}
-
-			if (!isJson)
-				isJson =
-					headers.has('content-type') &&
-					!!~headers.get('content-type').indexOf('application/json');
-
-			yield isJson
-				? JSON.parse(data.toString('utf8'))
-				: data.toString('utf8');
-
-			if (!!~buffer.indexOf(boundary + '--')) {
-				break;
-			}
-
-			buffer = buffer.slice(boundaryIndex + boundary.length);
+		const headers: Map<string, string> = new Map();
+		for (let item of payload
+			.slice(0, headerSeparated)
+			.toString('utf8')
+			.trim()
+			.split(/\r\n/)) {
+			const idx = item.indexOf(':');
+			headers.set(
+				item.slice(0, idx).toLowerCase(),
+				item.slice(idx + 1).trim(),
+			);
 		}
+
+		data = data.slice(data.indexOf(separator) + separator.length);
+
+		const clength = headers.get('content-length');
+		if (clength != null) {
+			data = data.slice(0, parseInt(clength, 10));
+		}
+
+		if (!isJson) {
+			isJson = !!~(headers.get('content-type') || '').indexOf(
+				'application/json',
+			);
+		}
+
+		yield isJson
+			? JSON.parse(data.toString('utf8'))
+			: data.toString('utf8');
+
+		if (!!~buffer.indexOf(boundary + '--')) break;
+
+		buffer = buffer.slice(boundaryIndex + boundary.length);
 	}
 }

--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -6,57 +6,63 @@ export async function* generate<T>(
 	stream: Readable,
 	boundary: string,
 ): AsyncGenerator<T> {
+	let last_index = 0;
 	let buffer = Buffer.alloc(0);
 	let isPreamble = true;
 	let isJson = false;
 
 	for await (const chunk of stream) {
-		buffer = Buffer.concat([buffer, chunk], buffer.length + chunk.length);
-		const boundaryIndex = buffer.indexOf(boundary);
-		if (!~boundaryIndex) continue;
+		const idx_chunk = (chunk as Buffer).indexOf(boundary);
+
+		let idx_boundary = buffer.length;
+		buffer = Buffer.concat([buffer, chunk]);
+
+		if (!!~idx_chunk) {
+			// chunk itself had `boundary` marker
+			idx_boundary += idx_chunk;
+		} else {
+			// search combined (boundary can be across chunks)
+			idx_boundary = buffer.indexOf(boundary, last_index);
+
+			if (!~idx_boundary) {
+				// rewind a bit for next `indexOf`
+				last_index = buffer.length - chunk.length;
+				continue;
+			}
+		}
+
+		const next = buffer.slice(idx_boundary + boundary.length);
+		const current = buffer.slice(0, idx_boundary);
 
 		if (isPreamble) {
-			buffer = buffer.slice(boundaryIndex + boundary.length);
+			buffer = next;
 			isPreamble = false;
 			continue;
 		}
 
-		const payload = buffer.slice(0, boundaryIndex);
-		const headerSeparated = payload.indexOf(separator);
-		let data = payload.slice(headerSeparated);
+		let ctype = '', clength = '';
+		const idx_headers = current.indexOf(separator);
 
-		const headers: Map<string, string> = new Map();
-		for (let item of payload
-			.slice(0, headerSeparated)
-			.toString('utf8')
-			.trim()
-			.split(/\r\n/)) {
-			const idx = item.indexOf(':');
-			headers.set(
-				item.slice(0, idx).toLowerCase(),
-				item.slice(idx + 1).trim(),
-			);
-		}
+		// parse headers, only keeping relevant headers
+		buffer.slice(0, idx_headers).toString('utf8').trim().split(/\r\n/).forEach((str, idx) => {
+			idx = str.indexOf(':');
+			let key = str.substring(0, idx).toLowerCase();
+			if (key === 'content-type') ctype = str.substring(idx + 1).trim();
+			else if (key === 'content-length') clength = str.substring(idx + 1).trim();
+		});
 
-		data = data.slice(data.indexOf(separator) + separator.length);
+		let payload = current.slice(idx_headers + separator.length);
+		if (clength) payload = payload.slice(0, parseInt(clength, 10));
 
-		const clength = headers.get('content-length');
-		if (clength != null) {
-			data = data.slice(0, parseInt(clength, 10));
-		}
-
-		if (!isJson) {
-			isJson = !!~(headers.get('content-type') || '').indexOf(
-				'application/json',
-			);
-		}
+		isJson = isJson || !!~ctype.indexOf('application/json');
 
 		yield isJson
-			? JSON.parse(data.toString('utf8'))
-			: data.toString('utf8');
+			? JSON.parse(payload.toString('utf8'))
+			: payload.toString('utf8');
 
-		if (!!~buffer.indexOf(boundary + '--')) break;
+		if (next.slice(0, 2).toString() === '--') break;
 
-		buffer = buffer.slice(boundaryIndex + boundary.length);
+		buffer = next;
+		last_index = 0;
 	}
 }

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,27 +1,21 @@
-import type { IncomingMessage } from 'http';
 import { generate } from './lib/node';
 
+import type { IncomingMessage } from 'http';
+
 export async function meros<T>(res: IncomingMessage) {
-	if (!('content-type' in res.headers)) {
-		throw new Error('There was no content-type header');
-	}
+	const ctype = res.headers['content-type'];
 
-	if (!/multipart\/mixed/.test(res.headers['content-type'])) {
-		return res;
-	}
+	if (!ctype) throw new Error('There was no content-type header');
+	if (!/multipart\/mixed/.test(ctype)) return res;
 
-	const boundaryIndex = res.headers['content-type'].indexOf('boundary=');
+	const boundaryIndex = ctype.indexOf('boundary=');
 
 	return generate<T>(
 		res,
 		'--' +
 			(!!~boundaryIndex
-				? res.headers['content-type']
-						.substring(
-							// +9 for 'boundary='.length
-							boundaryIndex + 9,
-						)
-						.trim()
+				? // +9 for 'boundary='.length
+				  ctype.substring(boundaryIndex + 9).trim()
 				: '-'),
 	);
 }

--- a/tests/node.spec.ts
+++ b/tests/node.spec.ts
@@ -28,13 +28,13 @@ test('can make a call', async (context) => {
 	const response = await makeCall(context.port);
 	const parts = await meros.meros<object>(response);
 
-	let collection: Array<object> = [],
-		itt = 0;
+	let collection: Array<object> = [];
 
 	for await (let part of parts) {
-		++itt;
 		collection.push(part);
 	}
+
+	assert.is(collection.length, 5);
 
 	assert.equal(collection, [
 		{ hello: 'world' },
@@ -43,7 +43,6 @@ test('can make a call', async (context) => {
 		{ massive: { nested: { world: 'okay' } } },
 		'should be plain text',
 	]);
-	assert.equal(itt, 5);
 });
 
 test.run();


### PR DESCRIPTION
> Currently based on #3 but should land _after_ that, with updated base branch, if at all

**Main Points**

* Tracks `last_index` so that the `indexOf` searches can operate on smaller chunks whenever possible.
* Maintains `current` vs `next` buffer slices -- easier to grok mentally
* Only keeps `header` values worth keeping