### PR TITLE
perf(browser): use `while true` loop

### DIFF
--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -13,11 +13,8 @@ export async function* generate<T>(
 	let is_json = true;
 
 	try {
-		let done;
-
-		do {
+		while (true) {
 			const result = await reader.read();
-			done = result.done;
 			const chunk =  decoder.decode(result.value);
 
 			const idx_chunk = buffer.indexOf(boundary);
@@ -67,11 +64,11 @@ export async function* generate<T>(
 				? JSON.parse(payload.toString())
 				: payload.toString();
 
-			if (next.slice(0, 2).toString() === '--') break;
+			if (result.done || next.slice(0, 2).toString() === '--') break;
 
 			buffer = next;
 			last_index = 0;
-		} while (!done);
+		}
 	} finally {
 		reader.releaseLock();
 	}


### PR DESCRIPTION
before: 

```
  meros                     x 2,865 ops/sec ±2.12% (61 runs sampled)
  fetch-multipart-graphql   x 2,656 ops/sec ±1.13% (65 runs sampled)
```

after:

```
  meros                     x 3,266 ops/sec ±0.64% (56 runs sampled)
  fetch-multipart-graphql   x 2,566 ops/sec ±1.53% (66 runs sampled)
```