### PR TITLE
fix(browser): exhaust `next` buffer parts

### DIFF
--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -18,7 +18,7 @@ export async function* generate<T>(
 			const chunk = decoder.decode(result.value);
 
 			let idx_boundary = buffer.length;
-			const idx_chunk = buffer.indexOf(boundary);
+			const idx_chunk = chunk.indexOf(boundary);
 			buffer += chunk;
 
 			if (!!~idx_chunk) {

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -37,8 +37,8 @@ export async function* generate<T>(
 			}
 
 			while (!!~idx_boundary) {
-			const current = buffer.slice(0, idx_boundary);
-				const next = buffer.slice(idx_boundary + boundary.length);
+				const current = buffer.substring(0, idx_boundary);
+				const next = buffer.substring(idx_boundary + boundary.length);
 
 			if (is_preamble) {
 				is_preamble = false;
@@ -47,21 +47,21 @@ export async function* generate<T>(
 			const idx_headers = current.indexOf(separator);
 
 			// parse headers, only keeping relevant headers
-			buffer.slice(0, idx_headers).toString().trim().split(/\r\n/).forEach((str, idx) => {
+					buffer.substring(0, idx_headers).toString().trim().split(/\r\n/).forEach((str, idx) => {
 				idx = str.indexOf(':');
 				let key = str.substring(0, idx).toLowerCase();
 				if (key === 'content-type') ctype = str.substring(idx + 1).trim();
 				else if (key === 'content-length') clength = str.substring(idx + 1).trim();
 			});
 
-			let payload = current.slice(idx_headers + separator.length);
+					let payload = current.substring(idx_headers + separator.length);
 			// TODO: clength is in bytes which isnt the same as an index into array
-			if (clength) payload = payload.slice(0, parseInt(clength, 10));
+					if (clength) payload = payload.substring(0, parseInt(clength, 10));
 
 			is_json = ctype ? !!~ctype.indexOf('application/json') : is_json;
 			yield is_json ? JSON.parse(payload.toString()) : payload.toString();
 
-					if (next.slice(0, 2).toString() === '--') break outer;
+					if (next.substring(0, 2).toString() === '--') break outer;
 				}
 
 				buffer=next; last_index=0;

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -16,6 +16,7 @@ export async function* generate<T>(
 		outer: while (true) {
 			const result = await reader.read();
 			const chunk = decoder.decode(result.value);
+			if (result.done) break outer;
 
 			let idx_boundary = buffer.length;
 			const idx_chunk = chunk.indexOf(boundary);
@@ -60,7 +61,7 @@ export async function* generate<T>(
 			is_json = ctype ? !!~ctype.indexOf('application/json') : is_json;
 			yield is_json ? JSON.parse(payload.toString()) : payload.toString();
 
-					if (result.done || next.slice(0, 2).toString() === '--') break outer;
+					if (next.slice(0, 2).toString() === '--') break outer;
 				}
 
 				buffer=next; last_index=0;

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -47,7 +47,7 @@ export async function* generate<T>(
 			const idx_headers = current.indexOf(separator);
 
 			// parse headers, only keeping relevant headers
-					buffer.substring(0, idx_headers).toString().trim().split(/\r\n/).forEach((str, idx) => {
+					buffer.substring(0, idx_headers).trim().split(/\r\n/).forEach((str, idx) => {
 				idx = str.indexOf(':');
 				let key = str.substring(0, idx).toLowerCase();
 				if (key === 'content-type') ctype = str.substring(idx + 1).trim();
@@ -59,9 +59,9 @@ export async function* generate<T>(
 					if (clength) payload = payload.substring(0, parseInt(clength, 10));
 
 			is_json = ctype ? !!~ctype.indexOf('application/json') : is_json;
-			yield is_json ? JSON.parse(payload.toString()) : payload.toString();
+					yield is_json ? JSON.parse(payload) : payload;
 
-					if (next.substring(0, 2).toString() === '--') break outer;
+					if (next.substring(0, 2) === '--') break outer;
 				}
 
 				buffer=next; last_index=0;

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -1,6 +1,5 @@
-const decoder = new TextDecoder();
-
 const separator = '\r\n\r\n';
+const decoder = new TextDecoder;
 
 export async function* generate<T>(
 	stream: ReadableStream<Uint8Array>,
@@ -15,10 +14,10 @@ export async function* generate<T>(
 	try {
 		outer: while (true) {
 			const result = await reader.read();
-			const chunk = decoder.decode(result.value);
-			if (result.done) break outer;
+			if (result.done) break outer; // undefined value
 
 			let idx_boundary = buffer.length;
+			const chunk = decoder.decode(result.value);
 			const idx_chunk = chunk.indexOf(boundary);
 			buffer += chunk;
 


### PR DESCRIPTION
Same approach as #6 – test _appeared_ to be failing single-chunk, but it was the result of concatenation across chunks.

I have a fix locally for the UTF8 test (`👀`) – sent you a message about it.

---

Based on #6, which should land 1st and then this PR changes its base.