### PR TITLE
fix(browser): use `bytes` for `content-length` slicing

### DIFF
--- a/lib/mocks.ts
+++ b/lib/mocks.ts
@@ -1,19 +1,10 @@
 // @ts-nocheck
-
+import { TextDecoder, TextEncoder } from 'util';
 import type { IncomingMessage } from 'http';
 
 // Mocks for Node@10
-global['TextDecoder'] =
-	global['TextDecoder'] ||
-	class {
-		decode(arr: Uint8Array) {
-			let str = '';
-			for (let i = 0; i < arr.length; i++) {
-				str += String.fromCharCode(arr[i]);
-			}
-			return str;
-		}
-	};
+global['TextDecoder'] = global['TextDecoder'] || TextDecoder;
+global['TextEncoder'] = global['TextEncoder'] || TextEncoder;
 
 export function makeChunk(
 	payload: any,


### PR DESCRIPTION
Encodes _just_ the `payload` chunk to get appropriate `byteLength` and then decodes a subarray of that view to get back to a string representation.

This variant is 19k op/s, up from the 17k I told you about.

Down the road, will finish my package to do this (hopefully) a bit more quickly