### PR TITLE
feat: introduces multiple payloads option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,12 +20,18 @@ type Arrayable<T> = T | ReadonlyArray<T>;
 
 // Browser~
 
-declare function meros<T = object>(response: Response, options: {
-	multiple: true;
-}): Promise<Response | AsyncGenerator<ReadonlyArray<Part<T, Buffer>>>>;
-declare function meros<T = object>(response: Response, options?: {
-	multiple: false;
-}): Promise<Response | AsyncGenerator<Part<T, Buffer>>>;
+declare function meros<T = object>(
+	response: Response,
+	options: {
+		multiple: true;
+	},
+): Promise<Response | AsyncGenerator<ReadonlyArray<Part<T, Buffer>>>>;
+declare function meros<T = object>(
+	response: Response,
+	options?: {
+		multiple: false;
+	},
+): Promise<Response | AsyncGenerator<Part<T, Buffer>>>;
 /**
  * Yield immediately for every part made available on the response. If the `content-type` of the response isn't a
  * multipart body, then we'll resolve with {@link Response}.
@@ -41,16 +47,25 @@ declare function meros<T = object>(response: Response, options?: {
  * }
  * ```
  */
-declare function meros<T = object>(response: Response, options?: Options): Promise<Response | AsyncGenerator<Arrayable<Part<T, Buffer>>>>;
+declare function meros<T = object>(
+	response: Response,
+	options?: Options,
+): Promise<Response | AsyncGenerator<Arrayable<Part<T, Buffer>>>>;
 
 // Node~
 
-declare function meros<T = object>(response: IncomingMessage, options: {
-	multiple: true;
-}): Promise<IncomingMessage | AsyncGenerator<ReadonlyArray<Part<T, Buffer>>>>;
-declare function meros<T = object>(response: IncomingMessage, options?: {
-	multiple: false;
-}): Promise<IncomingMessage | AsyncGenerator<Part<T, Buffer>>>;
+declare function meros<T = object>(
+	response: IncomingMessage,
+	options: {
+		multiple: true;
+	},
+): Promise<IncomingMessage | AsyncGenerator<ReadonlyArray<Part<T, Buffer>>>>;
+declare function meros<T = object>(
+	response: IncomingMessage,
+	options?: {
+		multiple: false;
+	},
+): Promise<IncomingMessage | AsyncGenerator<Part<T, Buffer>>>;
 /**
  * Yield immediately for every part made available on the response. If the `content-type` of the response isn't a
  * multipart body, then we'll resolve with {@link IncomingMessage}.
@@ -72,6 +87,9 @@ declare function meros<T = object>(response: IncomingMessage, options?: {
  * }
  * ```
  */
-declare function meros<T = object>(response: IncomingMessage, options?: Options): Promise<IncomingMessage | AsyncGenerator<Arrayable<Part<T, Buffer>>>>;
+declare function meros<T = object>(
+	response: IncomingMessage,
+	options?: Options,
+): Promise<IncomingMessage | AsyncGenerator<Arrayable<Part<T, Buffer>>>>;
 
 export { meros };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,16 @@
 /// <reference types="node" />
 import { IncomingMessage } from 'http';
 
+interface Options {
+	multiple: boolean;
+}
+
 type Part<Body, Fallback> =
-	| { json: true, headers: Record<string, string>, body: Body }
-	| { json: false, headers: Record<string, string>, body: Fallback };
+	| { json: boolean; headers: Record<string, string>; body: Body | Fallback }
+	| { json: false; headers: Record<string, string>; body: Fallback }
+	| { json: true; headers: Record<string, string>; body: Body };
+
+type Arrayable<T> = T | ReadonlyArray<T>;
 
 /**
  * Yield immediately for every part made available on the response. If the `content-type` of the response isn't a
@@ -20,7 +27,7 @@ type Part<Body, Fallback> =
  * }
  * ```
  */
-declare function meros<T = object>(response: Response): Promise<Response | AsyncGenerator<Part<T, string>>>;
+declare function meros<T = object>(response: Response, options?: Options): Promise<Response | AsyncGenerator<Arrayable<Part<T, string>>, any, unknown>>;
 
 /**
  * Yield immediately for every part made available on the response. If the `content-type` of the response isn't a
@@ -43,6 +50,6 @@ declare function meros<T = object>(response: Response): Promise<Response | Async
  * }
  * ```
  */
-declare function meros<T = object>(response: IncomingMessage): Promise<IncomingMessage | AsyncGenerator<Part<T, Buffer>>>;
+declare function meros<T = object>(response: IncomingMessage, options?: Options): Promise<IncomingMessage | AsyncGenerator<Arrayable<Part<T, Buffer>>, any, unknown>>;
 
 export { meros };

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,12 @@
 import { IncomingMessage } from 'http';
 
 interface Options {
+	/**
+	 * Setting this to true will yield an array. In other words; instead of yielding once for every payload—we collect
+	 * all complete payloads for a chunk and then yield.
+	 *
+	 * @default false
+	 */
 	multiple: boolean;
 }
 
@@ -12,6 +18,14 @@ type Part<Body, Fallback> =
 
 type Arrayable<T> = T | ReadonlyArray<T>;
 
+// Browser~
+
+declare function meros<T = object>(response: Response, options: {
+	multiple: true;
+}): Promise<Response | AsyncGenerator<ReadonlyArray<Part<T, Buffer>>>>;
+declare function meros<T = object>(response: Response, options?: {
+	multiple: false;
+}): Promise<Response | AsyncGenerator<Part<T, Buffer>>>;
 /**
  * Yield immediately for every part made available on the response. If the `content-type` of the response isn't a
  * multipart body, then we'll resolve with {@link Response}.
@@ -27,8 +41,16 @@ type Arrayable<T> = T | ReadonlyArray<T>;
  * }
  * ```
  */
-declare function meros<T = object>(response: Response, options?: Options): Promise<Response | AsyncGenerator<Arrayable<Part<T, string>>, any, unknown>>;
+declare function meros<T = object>(response: Response, options?: Options): Promise<Response | AsyncGenerator<Arrayable<Part<T, Buffer>>>>;
 
+// Node~
+
+declare function meros<T = object>(response: IncomingMessage, options: {
+	multiple: true;
+}): Promise<IncomingMessage | AsyncGenerator<ReadonlyArray<Part<T, Buffer>>>>;
+declare function meros<T = object>(response: IncomingMessage, options?: {
+	multiple: false;
+}): Promise<IncomingMessage | AsyncGenerator<Part<T, Buffer>>>;
 /**
  * Yield immediately for every part made available on the response. If the `content-type` of the response isn't a
  * multipart body, then we'll resolve with {@link IncomingMessage}.
@@ -50,6 +72,6 @@ declare function meros<T = object>(response: Response, options?: Options): Promi
  * }
  * ```
  */
-declare function meros<T = object>(response: IncomingMessage, options?: Options): Promise<IncomingMessage | AsyncGenerator<Arrayable<Part<T, Buffer>>, any, unknown>>;
+declare function meros<T = object>(response: IncomingMessage, options?: Options): Promise<IncomingMessage | AsyncGenerator<Arrayable<Part<T, Buffer>>>>;
 
 export { meros };

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 	},
 	"devDependencies": {
 		"@marais/tsconfig": "0.0.1",
-		"@n1ru4l/push-pull-async-iterable-iterator": "^2.0.1",
+		"@n1ru4l/push-pull-async-iterable-iterator": "2.0.1",
 		"@rollup/plugin-node-resolve": "11.1.1",
 		"@types/benchmark": "2.1.0",
 		"@types/node": "14.14.25",
@@ -85,7 +85,7 @@
 		"fetch-multipart-graphql": "3.0.0",
 		"it-multipart": "1.0.6",
 		"prettier": "2.2.1",
-		"rollup": "2.38.4",
+		"rollup": "2.38.5",
 		"rollup-plugin-dts": "2.0.1",
 		"rollup-plugin-filesize": "9.1.0",
 		"rollup-plugin-terser": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "meros",
 	"version": "1.1.0",
-	"description": "A fast 633B utility that makes reading multipart responses simple",
+	"description": "A fast 610B utility that makes reading multipart responses simple",
 	"keywords": [
 		"defer",
 		"fetch",
@@ -50,7 +50,7 @@
 	"scripts": {
 		"bench": "node -r ts-node/register -r ./test/_polyfill.js bench/index.ts",
 		"build": "rollup -c",
-		"format": "prettier  --write --list-different \"{*,.github/**/*}.+(json|yml|md)\"",
+		"format": "prettier  --write --list-different \"{*,.github/**/*}.+(ts|json|yml|md)\"",
 		"prepublishOnly": "yarn build",
 		"test": "uvu -r ts-node/register -r ./test/_polyfill.js -i _polyfill -i mocks test",
 		"typecheck": "tsc --noEmit"
@@ -77,6 +77,7 @@
 	},
 	"devDependencies": {
 		"@marais/tsconfig": "0.0.1",
+		"@n1ru4l/push-pull-async-iterable-iterator": "^2.0.1",
 		"@rollup/plugin-node-resolve": "11.1.1",
 		"@types/benchmark": "2.1.0",
 		"@types/node": "14.14.25",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "meros",
-	"version": "1.0.0",
-	"description": "A fast 699B utility that makes reading multipart responses simple",
+	"version": "1.1.0",
+	"description": "A fast 633B utility that makes reading multipart responses simple",
 	"keywords": [
 		"defer",
 		"fetch",

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ yarn add meros
 // Rely on bundler/environment dection
 import { meros } from 'meros';
 
-const parts = await fetch('/fetch-multipart').then(meros);
+const parts = await fetch('/api').then(meros);
 
 // As a simple Async Generator
 for await (const part of parts) {
@@ -58,7 +58,7 @@ from(parts).pipe(
 import { meros } from 'meros/browser';
 // import { meros } from 'https://cdn.skypack.dev/meros';
 
-const parts = await fetch('/fetch-multipart').then(meros);
+const parts = await fetch('/api').then(meros);
 
 // Node
 import http from 'http';
@@ -99,40 +99,27 @@ collide with things from the body:
 
 ## 🔎 API
 
-### _Browser_
+Meros offers two flavours, both for the browser and for node; but their api's
+are fundamentally the same.
+
+> **Note:** The type `Response` is used loosely here and simply alludes to
+> Node's `IncomingMessage` or the browser's `Response` type.
+
+### `meros(response: Response, options?: Options)`
+
+Returns: `Promise<Response | AsyncGenerator<Part | Part[]>`
+
+Meros returns a promise that will resolve to an `AsyncGenerator` if the response
+is of `multipart/mixed` mime, or simply returns the `Response` if something
+else; helpful for middlewares. The idea here being that you put run meros at the
+.then of the fetch api.
 
 ```ts
-function meros<T = object>(
-  response: Response,
-): Promise<
-  | Response
-  | AsyncGenerator<
-      | { json: true; headers: Record<string, string>; body: T }
-      | { json: false; headers: Record<string, string>; body: string }
-    >
->;
+fetch('/api').then(meros);
 ```
 
-### _Node_
-
-```ts
-function meros<T = object>(
-  response: IncomingMessage,
-): Promise<
-  | IncomingMessage
-  | AsyncGenerator<
-      | { json: true; headers: Record<string, string>; body: T }
-      | { json: false; headers: Record<string, string>; body: Buffer }
-    >
->;
-```
-
-Returns an async generator that yields on every part. Worth noting that if
-multiple parts are present in one chunk, each part will yield independently.
-
-> If the `content-type` is **NOT** a multipart, then it will resolve with the
-> response argument. Or really any unhandled cases, we'll resolve with the
-> response.
+> If the `content-type` is **NOT** a multipart, then meros will resolve with the
+> response argument.
 >
 > <details>
 > <summary>Example on how to handle this case</summary>
@@ -140,7 +127,7 @@ multiple parts are present in one chunk, each part will yield independently.
 > ```ts
 > import { meros } from 'meros';
 >
-> const response = await fetch('/fetch-multipart'); // Assume this returns json
+> const response = await fetch('/api'); // Assume this returns json
 > const parts = await meros(response);
 >
 > if (parts[Symbol.asyncIterator] < 'u') {
@@ -153,6 +140,40 @@ multiple parts are present in one chunk, each part will yield independently.
 > ```
 >
 > </details>
+
+each `Part` gives you access to:
+
+- `json: boolean` ~ Tells you the `body` would be a JavaScript object of your
+  defined generic `T`.
+- `headers: object` ~ A key-value pair of all headers discovered from this part.
+- `body: T | Fallback` ~ Is the _body_ of the part, either as a JavaScript
+  object (noted by `json`) _or_ the base type of the environment
+  (`Buffer | string`, for Node and Browser respectively).
+
+### `options.multiple: boolean`
+
+Default: `false`
+
+Setting this to `true` will yield once for all available parts of a chunk,
+rather than yielding once per part. This is an optimization technique for
+technologies like GraphQL where rather than commit the payload to the store, to
+be added-to in the next process-tick we can simply do that synchronously.
+
+> **Important:** This will alter the behaviour and yield arrays—than yield
+> payloads.
+
+```ts
+const chunks = await fetch('/api').then((response) =>
+  meros(response, { multiple: true }),
+);
+
+// As a simple Async Generator
+for await (const parts of chunks) {
+  for (const part of parts) {
+    // Do something with this part, maybe aggregate?
+  }
+}
+```
 
 ## 💨 Benchmark
 

--- a/readme.md
+++ b/readme.md
@@ -183,19 +183,19 @@ Validation :: node
 ✘ it-multipart (FAILED @ "should match reference patch set")
 
 Benchmark :: node
-  meros                     x 27,567 ops/sec ±2.04% (77 runs sampled)
-  it-multipart              x 16,064 ops/sec ±1.20% (79 runs sampled)
+  meros                     x 28,232 ops/sec ±0.91% (77 runs sampled)
+  it-multipart              x 16,909 ops/sec ±0.55% (79 runs sampled)
 
 Validation :: browser
 ✔ meros
 ✘ fetch-multipart-graphql (FAILED @ "should match reference patch set")
 
 Benchmark :: browser
-  meros                     x 30,077 ops/sec ±0.92% (80 runs sampled)
-  fetch-multipart-graphql   x 25,551 ops/sec ±1.44% (81 runs sampled)
+  meros                     x 29,291 ops/sec ±0.50% (76 runs sampled)
+  fetch-multipart-graphql   x 27,804 ops/sec ±0.55% (82 runs sampled)
 ```
 
-> Ran with Node v15.1.0
+> Ran with Node v15.8.0
 
 ## ❤ Thanks
 

--- a/readme.md
+++ b/readme.md
@@ -111,8 +111,8 @@ Returns: `Promise<Response | AsyncGenerator<Part | Part[]>`
 
 Meros returns a promise that will resolve to an `AsyncGenerator` if the response
 is of `multipart/mixed` mime, or simply returns the `Response` if something
-else; helpful for middlewares. The idea here being that you put run meros at the
-.then of the fetch api.
+else; helpful for middlewares. The idea here being that you run meros as a chain
+off fetch.
 
 ```ts
 fetch('/api').then(meros);
@@ -150,7 +150,7 @@ each `Part` gives you access to:
   object (noted by `json`) _or_ the base type of the environment
   (`Buffer | string`, for Node and Browser respectively).
 
-### `options.multiple: boolean`
+#### `options.multiple: boolean`
 
 Default: `false`
 

--- a/readme.md
+++ b/readme.md
@@ -183,16 +183,16 @@ Validation :: node
 ✘ it-multipart (FAILED @ "should match reference patch set")
 
 Benchmark :: node
-  meros                     x 28,232 ops/sec ±0.91% (77 runs sampled)
-  it-multipart              x 16,909 ops/sec ±0.55% (79 runs sampled)
+  meros                     x 289,318 ops/sec ±1.21% (81 runs sampled)
+  it-multipart              x 173,136 ops/sec ±0.85% (80 runs sampled)
 
 Validation :: browser
 ✔ meros
 ✘ fetch-multipart-graphql (FAILED @ "should match reference patch set")
 
 Benchmark :: browser
-  meros                     x 29,291 ops/sec ±0.50% (76 runs sampled)
-  fetch-multipart-graphql   x 27,804 ops/sec ±0.55% (82 runs sampled)
+  meros                     x 1,000,417 ops/sec ±1.41% (81 runs sampled)
+  fetch-multipart-graphql   x 353,207 ops/sec ±0.92% (83 runs sampled)
 ```
 
 > Ran with Node v15.8.0

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,4 +1,5 @@
 import { generate } from './lib/browser';
+import type { Options } from './lib/types';
 
 /**
  * Yield immediately for every part made available on the response. If the `content-type` of the response isn't a
@@ -15,7 +16,7 @@ import { generate } from './lib/browser';
  * }
  * ```
  */
-export async function meros<T=object>(response: Response) {
+export async function meros<T=object>(response: Response, options: Options = { multiple: false }) {
 	if (!response.ok || !response.body || response.bodyUsed) return response;
 
 	const ctype = response.headers.get('content-type');
@@ -29,5 +30,6 @@ export async function meros<T=object>(response: Response) {
 			? // +9 for 'boundary='.length
 			ctype.substring(idx_boundary + 9).trim().replace(/['"]/g, '')
 			: '-'}`,
+		options
 	);
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -16,7 +16,7 @@ import type { Options } from './lib/types';
  * }
  * ```
  */
-export async function meros<T=object>(response: Response, options: Options = { multiple: false }) {
+export async function meros<T=object>(response: Response, options?: Options) {
 	if (!response.ok || !response.body || response.bodyUsed) return response;
 
 	const ctype = response.headers.get('content-type');

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,5 +1,9 @@
 import { generate } from './lib/browser';
-import type { Options } from './lib/types';
+import type { Arrayable, Options, Part } from './lib/types';
+
+export function meros<T=object>(response: Response, options: { multiple: true }): Promise<Response | AsyncGenerator<ReadonlyArray<Part<T, Buffer>>>>;
+export function meros<T=object>(response: Response, options?: { multiple: false }): Promise<Response | AsyncGenerator<Part<T, Buffer>>>;
+export function meros<T=object>(response: Response, options?: Options): Promise<Response | AsyncGenerator<Arrayable<Part<T, Buffer>>>>;
 
 /**
  * Yield immediately for every part made available on the response. If the `content-type` of the response isn't a

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -1,6 +1,5 @@
 import type { Options, Part, Arrayable } from './types';
 
-
 const separator = '\r\n\r\n';
 const decoder = new TextDecoder;
 

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -3,10 +3,6 @@ import type { Options, Part, Arrayable } from './types';
 const separator = '\r\n\r\n';
 const decoder = new TextDecoder;
 
-export function generate<T>(stream: ReadableStream<Uint8Array>, boundary: string, options: { multiple: true }): AsyncGenerator<ReadonlyArray<Part<T, string>>>;
-export function generate<T>(stream: ReadableStream<Uint8Array>, boundary: string, options?: { multiple: false }): AsyncGenerator<Part<T, string>>;
-export function generate<T>(stream: ReadableStream<Uint8Array>, boundary: string, options?: Options): AsyncGenerator<Arrayable<Part<T, string>>>;
-
 export async function* generate<T>(
 	stream: ReadableStream<Uint8Array>,
 	boundary: string,

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -1,4 +1,4 @@
-import type { Options, Part, Arrayable } from './types';
+import type { Arrayable, Options, Part } from './types';
 
 const separator = '\r\n\r\n';
 const decoder = new TextDecoder;
@@ -72,7 +72,12 @@ export async function* generate<T>(
 					is_eager ? yield tmp : payloads.push(tmp);
 
 					// hit a tail boundary, break
-					if (next.substring(0, 2) === '--') break outer;
+					if (next.substring(0, 2) === '--') {
+						if (payloads.length) {
+							yield payloads;
+						}
+						break outer;
+					}
 				}
 
 				buffer = next;

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -12,7 +12,6 @@ export async function* generate<T>(
 		is_eager = !options || !options.multiple;
 
 	let buffer = '',
-		last_index = 0,
 		is_preamble = true,
 		payloads = [];
 
@@ -29,13 +28,7 @@ export async function* generate<T>(
 				idx_boundary += idx_chunk;
 			} else {
 				// search combined (boundary can be across chunks)
-				idx_boundary = buffer.indexOf(boundary, last_index);
-
-				if (!~idx_boundary) {
-					// rewind a bit for next `indexOf`
-					last_index = buffer.length - chunk.length;
-					continue;
-				}
+				idx_boundary = buffer.indexOf(boundary);
 			}
 
 			payloads = [];
@@ -77,7 +70,6 @@ export async function* generate<T>(
 				}
 
 				buffer = next;
-				last_index = 0;
 				idx_boundary = buffer.indexOf(boundary);
 			}
 

--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -3,10 +3,6 @@ import type { Options, Part, Arrayable } from './types';
 
 const separator = '\r\n\r\n';
 
-export function generate<T>(stream: Readable, boundary: string, options: { multiple: true }): AsyncGenerator<ReadonlyArray<Part<T, Buffer>>>;
-export function generate<T>(stream: Readable, boundary: string, options?: { multiple: false }): AsyncGenerator<Part<T, Buffer>>;
-export function generate<T>(stream: Readable, boundary: string, options?: Options): AsyncGenerator<Arrayable<Part<T, Buffer>>>;
-
 export async function* generate<T>(
 	stream: Readable,
 	boundary: string,

--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -12,12 +12,11 @@ export async function* generate<T>(
 		is_eager = !options || !options.multiple;
 
 	let buffer = Buffer.alloc(0),
-		last_index = 0,
 		is_preamble = true,
 		payloads = [];
 
 	outer: for await (const chunk of stream) {
-		let idx_boundary = buffer.length;
+		let idx_boundary = buffer.byteLength;
 		buffer = Buffer.concat([buffer, chunk]);
 		const idx_chunk = (chunk as Buffer).indexOf(boundary);
 
@@ -26,13 +25,7 @@ export async function* generate<T>(
 			idx_boundary += idx_chunk;
 		} else {
 			// search combined (boundary can be across chunks)
-			idx_boundary = buffer.indexOf(boundary, last_index);
-
-			if (!~idx_boundary) {
-				// rewind a bit for next `indexOf`
-				last_index = buffer.length - chunk.length;
-				continue;
-			}
+			idx_boundary = buffer.indexOf(boundary);
 		}
 
 		payloads = [];
@@ -74,7 +67,6 @@ export async function* generate<T>(
 			}
 
 			buffer = next;
-			last_index = 0;
 			idx_boundary = buffer.indexOf(boundary);
 		}
 

--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -54,7 +54,7 @@ export async function* generate<T>(
 					headers[tmp.shift().toLowerCase()] = tmp.join(': ');
 				}
 
-				let body: Buffer | T = current.slice(idx_headers + separator.length, current.lastIndexOf('\r\n'));
+				let body: T | Buffer = current.slice(idx_headers + separator.length, current.lastIndexOf('\r\n'));
 				let is_json = false;
 
 				tmp = headers['content-type'];

--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -1,18 +1,19 @@
 import type { Readable } from 'stream';
-import type { Options, Part } from './types';
+import type { Options, Part, Arrayable } from './types';
 
 const separator = '\r\n\r\n';
 
-export function generate<T>(stream: Readable, boundary: string, options: Options & { multiple: true }): AsyncGenerator<ReadonlyArray<Part<T, Buffer>>>;
-export function generate<T>(stream: Readable, boundary: string, options: Options & { multiple: false }): AsyncGenerator<Part<T, Buffer>>;
+export function generate<T>(stream: Readable, boundary: string, options: { multiple: true }): AsyncGenerator<ReadonlyArray<Part<T, Buffer>>>;
+export function generate<T>(stream: Readable, boundary: string, options?: { multiple: false }): AsyncGenerator<Part<T, Buffer>>;
+export function generate<T>(stream: Readable, boundary: string, options?: Options): AsyncGenerator<Arrayable<Part<T, Buffer>>>;
 
 export async function* generate<T>(
 	stream: Readable,
 	boundary: string,
-	options: Options
-): AsyncGenerator<ReadonlyArray<Part<T, Buffer>> | Part<T, Buffer>> {
+	options?: Options
+): AsyncGenerator<Arrayable<Part<T, Buffer>>> {
 	const len_boundary = Buffer.byteLength(boundary),
-		is_eager = !options.multiple;
+		is_eager = !options || !options.multiple;
 
 	let last_index = 0;
 	let buffer = Buffer.alloc(0);
@@ -57,24 +58,20 @@ export async function* generate<T>(
 					headers[tmp.shift().toLowerCase()] = tmp.join(': ');
 				}
 
-				let body = current.slice(idx_headers + separator.length, current.lastIndexOf('\r\n'));
+				let body: Buffer | T = current.slice(idx_headers + separator.length, current.lastIndexOf('\r\n'));
 				let is_json = false;
 
 				tmp = headers['content-type'];
 				if (tmp && !!~tmp.indexOf('application/json')) {
 					try {
-						body = JSON.parse(body.toString());
+						body = JSON.parse(body.toString()) as T;
 						is_json = true;
 					} catch (_) {
 					}
 				}
 
 				tmp = { headers, body, json: is_json };
-
-				is_eager
-					// @ts-expect-error
-					? yield tmp
-					: payloads.push(tmp);
+				is_eager ? yield tmp : payloads.push(tmp);
 
 				// hit a tail boundary, break
 				if (next.slice(0, 2).toString() === '--') break outer;
@@ -85,8 +82,8 @@ export async function* generate<T>(
 			idx_boundary = buffer.indexOf(boundary);
 		}
 
-		if (payloads.length)
-			// @ts-expect-error
+		if (payloads.length) {
 			yield payloads;
+		}
 	}
 }

--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -1,5 +1,5 @@
 import type { Readable } from 'stream';
-import type { Options, Part, Arrayable } from './types';
+import type { Arrayable, Options, Part } from './types';
 
 const separator = '\r\n\r\n';
 
@@ -70,7 +70,12 @@ export async function* generate<T>(
 				is_eager ? yield tmp : payloads.push(tmp);
 
 				// hit a tail boundary, break
-				if (next.slice(0, 2).toString() === '--') break outer;
+				if (next.slice(0, 2).toString() === '--') {
+					if (payloads.length) {
+						yield payloads;
+					}
+					break outer;
+				}
 			}
 
 			buffer = next;

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -1,3 +1,7 @@
 export type Part<Body, Fallback> =
 	| { json: true, headers: Record<string, string>, body: Body }
 	| { json: false, headers: Record<string, string>, body: Fallback };
+
+export interface Options {
+	multiple: boolean;
+}

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -1,7 +1,14 @@
+// export type Part<Body, Fallback> = { json: true; headers: Record<string, string>; body: Body };
+// export type Part<Body, Fallback> = { json: false; headers: Record<string, string>; body: Fallback };
+// export type Part<Body, Fallback> = { json: boolean; headers: Record<string, string>; body: Body | Fallback };
+
 export type Part<Body, Fallback> =
-	| { json: true, headers: Record<string, string>, body: Body }
-	| { json: false, headers: Record<string, string>, body: Fallback };
+	| { json: boolean; headers: Record<string, string>; body: Body | Fallback }
+	| { json: false; headers: Record<string, string>; body: Fallback }
+	| { json: true; headers: Record<string, string>; body: Body };
 
 export interface Options {
 	multiple: boolean;
 }
+
+export type Arrayable<T> = T | ReadonlyArray<T>;

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -1,14 +1,10 @@
-// export type Part<Body, Fallback> = { json: true; headers: Record<string, string>; body: Body };
-// export type Part<Body, Fallback> = { json: false; headers: Record<string, string>; body: Fallback };
-// export type Part<Body, Fallback> = { json: boolean; headers: Record<string, string>; body: Body | Fallback };
+export interface Options {
+	multiple: boolean;
+}
 
 export type Part<Body, Fallback> =
 	| { json: boolean; headers: Record<string, string>; body: Body | Fallback }
 	| { json: false; headers: Record<string, string>; body: Fallback }
 	| { json: true; headers: Record<string, string>; body: Body };
-
-export interface Options {
-	multiple: boolean;
-}
 
 export type Arrayable<T> = T | ReadonlyArray<T>;

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -1,4 +1,10 @@
 export interface Options {
+	/**
+	 * Setting this to true will yield an array. In other words; instead of yielding once for every payload—we collect
+	 * all complete payloads for a chunk and then yield.
+	 *
+	 * @default false
+	 */
 	multiple: boolean;
 }
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,6 +1,10 @@
 import type { IncomingMessage } from 'http';
 import { generate } from './lib/node';
-import type { Options } from './lib/types';
+import type { Arrayable, Options, Part } from './lib/types';
+
+export function meros<T=object>(response: IncomingMessage, options: { multiple: true }): Promise<IncomingMessage | AsyncGenerator<ReadonlyArray<Part<T, Buffer>>>>;
+export function meros<T=object>(response: IncomingMessage, options?: { multiple: false }): Promise<IncomingMessage | AsyncGenerator<Part<T, Buffer>>>;
+export function meros<T=object>(response: IncomingMessage, options?: Options): Promise<IncomingMessage | AsyncGenerator<Arrayable<Part<T, Buffer>>>>;
 
 /**
  * Yield immediately for every part made available on the response. If the `content-type` of the response isn't a

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage } from 'http';
 import { generate } from './lib/node';
+import type { Options } from './lib/types';
 
 /**
  * Yield immediately for every part made available on the response. If the `content-type` of the response isn't a
@@ -22,7 +23,7 @@ import { generate } from './lib/node';
  * }
  * ```
  */
-export async function meros<T=object>(response: IncomingMessage) {
+export async function meros<T=object>(response: IncomingMessage, options: Options = { multiple: false }) {
 	const ctype = response.headers['content-type'];
 	if (!ctype || !~ctype.indexOf('multipart/mixed')) return response;
 
@@ -34,5 +35,6 @@ export async function meros<T=object>(response: IncomingMessage) {
 			? // +9 for 'boundary='.length
 			ctype.substring(idx_boundary + 9).trim().replace(/['"]/g, '')
 			: '-'}`,
+		options
 	);
 }

--- a/src/node.ts
+++ b/src/node.ts
@@ -23,7 +23,7 @@ import type { Options } from './lib/types';
  * }
  * ```
  */
-export async function meros<T=object>(response: IncomingMessage, options: Options = { multiple: false }) {
+export async function meros<T=object>(response: IncomingMessage, options?: Options) {
 	const ctype = response.headers['content-type'];
 	if (!ctype || !~ctype.indexOf('multipart/mixed')) return response;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
 	},
 	"extends": "@marais/tsconfig",
 	"compilerOptions": {
-		"rootDir": "src",
+		"rootDir": ".",
 		"outDir": "dist",
 		"target": "ES2019",
 		"declaration": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,6 +35,11 @@
   resolved "https://registry.yarnpkg.com/@marais/tsconfig/-/tsconfig-0.0.1.tgz#32c6610e4790052e9259aea2bb85f33cf56f308f"
   integrity sha512-C/KwEPXqsDMrFT9BJ8xK9LR0O7uk1k9RzszqEgZIns7GwCaEt/m1oTbDvmRoQzRmtoqLpdQVUTPgIexUxJXhww==
 
+"@n1ru4l/push-pull-async-iterable-iterator@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@n1ru4l/push-pull-async-iterable-iterator/-/push-pull-async-iterable-iterator-2.0.1.tgz#8fc68e0e9e8bd3826d727b96ddd2afba2a7f26c7"
+  integrity sha512-3nDfpI/4WZgdocw75cxG4Qwmi3yp5zOleaT23EpVUhwVwlYzb4kDojl0nCZKB5lCGcTqT5wFlKepShs4Q+hymw==
+
 "@npmcli/ci-detect@^1.0.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@npmcli/ci-detect/-/ci-detect-1.3.0.tgz#6c1d2c625fb6ef1b9dea85ad0a5afcbef85ef22a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,30 +3,30 @@
 
 
 "@babel/code-frame@^7.10.4":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
-  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
+  integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
   dependencies:
-    "@babel/highlight" "^7.10.4"
+    "@babel/highlight" "^7.12.13"
 
-"@babel/helper-validator-identifier@^7.10.4":
+"@babel/helper-validator-identifier@^7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
   integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
 
-"@babel/highlight@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
-  integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
+"@babel/highlight@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.12.13.tgz#8ab538393e00370b26271b01fa08f7f27f2e795c"
+  integrity sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.10.4"
+    "@babel/helper-validator-identifier" "^7.12.11"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
 "@babel/runtime@^7.10.3":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
-  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
+  integrity sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -35,7 +35,7 @@
   resolved "https://registry.yarnpkg.com/@marais/tsconfig/-/tsconfig-0.0.1.tgz#32c6610e4790052e9259aea2bb85f33cf56f308f"
   integrity sha512-C/KwEPXqsDMrFT9BJ8xK9LR0O7uk1k9RzszqEgZIns7GwCaEt/m1oTbDvmRoQzRmtoqLpdQVUTPgIexUxJXhww==
 
-"@n1ru4l/push-pull-async-iterable-iterator@^2.0.1":
+"@n1ru4l/push-pull-async-iterable-iterator@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@n1ru4l/push-pull-async-iterable-iterator/-/push-pull-async-iterable-iterator-2.0.1.tgz#8fc68e0e9e8bd3826d727b96ddd2afba2a7f26c7"
   integrity sha512-3nDfpI/4WZgdocw75cxG4Qwmi3yp5zOleaT23EpVUhwVwlYzb4kDojl0nCZKB5lCGcTqT5wFlKepShs4Q+hymw==
@@ -60,15 +60,13 @@
     unique-filename "^1.1.1"
     which "^2.0.2"
 
-"@npmcli/installed-package-contents@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@npmcli/installed-package-contents/-/installed-package-contents-1.0.5.tgz#cc78565e55d9f14d46acf46a96f70934e516fa3d"
-  integrity sha512-aKIwguaaqb6ViwSOFytniGvLPb9SMCUm39TgM3SfUo7n0TxUMbwoXfpwyvQ4blm10lzbAwTsvjr7QZ85LvTi4A==
+"@npmcli/installed-package-contents@^1.0.6":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz#ab7408c6147911b970a8abe261ce512232a3f4fa"
+  integrity sha512-9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==
   dependencies:
     npm-bundled "^1.1.1"
     npm-normalize-package-bin "^1.0.1"
-    read-package-json-fast "^1.1.1"
-    readdir-scoped-modules "^1.1.0"
 
 "@npmcli/move-file@^1.0.1":
   version "1.1.1"
@@ -78,29 +76,29 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@npmcli/node-gyp@^1.0.0":
+"@npmcli/node-gyp@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@npmcli/node-gyp/-/node-gyp-1.0.1.tgz#dedc4ea9b3c6ef207081ebcd82c053ef60edc478"
   integrity sha512-pBqoKPWmuk9iaEcXlLBVRIA6I1kG9JiICU+sG0NuD6NAR461F+02elHJS4WkQxHW2W5rnsfvP/ClKwmsZ9RaaA==
 
-"@npmcli/promise-spawn@^1.1.0", "@npmcli/promise-spawn@^1.2.0", "@npmcli/promise-spawn@^1.3.0":
+"@npmcli/promise-spawn@^1.1.0", "@npmcli/promise-spawn@^1.2.0", "@npmcli/promise-spawn@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@npmcli/promise-spawn/-/promise-spawn-1.3.2.tgz#42d4e56a8e9274fba180dabc0aea6e38f29274f5"
   integrity sha512-QyAGYo/Fbj4MXeGdJcFzZ+FkDkomfRBrPM+9QYJSg+PxgAUL+LU3FneQk37rKR2/zjqkCV1BLHccX98wRXG3Sg==
   dependencies:
     infer-owner "^1.0.4"
 
-"@npmcli/run-script@^1.3.0":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@npmcli/run-script/-/run-script-1.8.1.tgz#729c5ac7293f250b654504d263952703af6da39c"
-  integrity sha512-G8c86g9cQHyRINosIcpovzv0BkXQc3urhL1ORf3KTe4TS4UBsg2O4Z2feca/W3pfzdHEJzc83ETBW4aKbb3SaA==
+"@npmcli/run-script@^1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@npmcli/run-script/-/run-script-1.8.2.tgz#528627e24da72a94e3156fb78056bca995a828a0"
+  integrity sha512-iwKq152Q62zG2rz/zRqT/OLDKcF1nBGTGmFdHRkTV8JRte6bUt18vPG4vOr/uoECecrIuJe1SSyvuUF32yt5BA==
   dependencies:
-    "@npmcli/node-gyp" "^1.0.0"
-    "@npmcli/promise-spawn" "^1.3.0"
+    "@npmcli/node-gyp" "^1.0.1"
+    "@npmcli/promise-spawn" "^1.3.2"
     infer-owner "^1.0.4"
     node-gyp "^7.1.0"
     puka "^1.0.1"
-    read-package-json-fast "^1.1.3"
+    read-package-json-fast "^2.0.1"
 
 "@rollup/plugin-node-resolve@11.1.1":
   version "11.1.1"
@@ -138,12 +136,7 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/node@*":
-  version "14.14.22"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.22.tgz#0d29f382472c4ccf3bd96ff0ce47daf5b7b84b18"
-  integrity sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==
-
-"@types/node@14.14.25":
+"@types/node@*", "@types/node@14.14.25":
   version "14.14.25"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.25.tgz#15967a7b577ff81383f9b888aa6705d43fbbae93"
   integrity sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==
@@ -168,9 +161,9 @@ agent-base@6:
     debug "4"
 
 agentkeepalive@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.1.3.tgz#360a09d743a1f4fde749f9ba07caa6575d08259a"
-  integrity sha512-wn8fw19xKZwdGPO47jivonaHRTd+nGOMP1z11sgGeQzDy2xd5FG0R67dIMcKHDE2cJ5y+YXV30XVGUBPRSY7Hg==
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.1.4.tgz#d928028a4862cb11718e55227872e842a44c945b"
+  integrity sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==
   dependencies:
     debug "^4.1.0"
     depd "^1.1.2"
@@ -252,11 +245,6 @@ arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
-
-asap@^2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
 asn1@~0.2.3:
   version "0.2.4"
@@ -517,11 +505,6 @@ debug@4, debug@^4.1.0:
   dependencies:
     ms "2.1.2"
 
-debuglog@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
-  integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
-
 deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
@@ -546,14 +529,6 @@ dequal@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
   integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
-
-dezalgo@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
-  integrity sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=
-  dependencies:
-    asap "^2.0.0"
-    wrappy "1"
 
 diff@^4.0.1:
   version "4.0.2"
@@ -609,6 +584,11 @@ err-code@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
   integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
+
+err-code@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
+  integrity sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -708,9 +688,9 @@ fs.realpath@^1.0.0:
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@~2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
-  integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -750,10 +730,10 @@ glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.3:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
-  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.3:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.5.tgz#bc18864a6c9fc7b303f2e2abdb9155ad178fbe29"
+  integrity sha512-kBBSQbz2K0Nyn+31j/w36fUfxkBW9/gfwRWdUY1ULReH3iokVJgddZAFcD1D0xlgTmFxJCbUkUclAlc6/IDJkw==
 
 gzip-size@^5.1.1:
   version "5.1.1"
@@ -1332,14 +1312,14 @@ p-try@^2.0.0:
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 pacote@^11.1.10:
-  version "11.2.4"
-  resolved "https://registry.yarnpkg.com/pacote/-/pacote-11.2.4.tgz#dc7ca740a573ed86a3bf863511d22c1d413ec82f"
-  integrity sha512-GfTeVQGJ6WyBQbQD4t3ocHbyOmTQLmWjkCKSZPmKiGFKYKNUaM5U2gbLzUW8WG1XmS9yQFnsTFA0k3o1+q4klQ==
+  version "11.2.6"
+  resolved "https://registry.yarnpkg.com/pacote/-/pacote-11.2.6.tgz#c0426e5d5c8d33aeea3461a75e1390f1ba78f953"
+  integrity sha512-xCl++Hb3aBC7LaWMimbO4xUqZVsEbKDVc6KKDIIyAeBYrmMwY1yJC2nES/lsGd8sdQLUosgBxQyuVNncZ2Ru0w==
   dependencies:
     "@npmcli/git" "^2.0.1"
-    "@npmcli/installed-package-contents" "^1.0.5"
+    "@npmcli/installed-package-contents" "^1.0.6"
     "@npmcli/promise-spawn" "^1.2.0"
-    "@npmcli/run-script" "^1.3.0"
+    "@npmcli/run-script" "^1.8.2"
     cacache "^15.0.5"
     chownr "^2.0.0"
     fs-minipass "^2.1.0"
@@ -1350,10 +1330,10 @@ pacote@^11.1.10:
     npm-packlist "^2.1.4"
     npm-pick-manifest "^6.0.0"
     npm-registry-fetch "^9.0.0"
-    promise-retry "^1.1.1"
-    read-package-json-fast "^1.1.3"
+    promise-retry "^2.0.1"
+    read-package-json-fast "^2.0.1"
     rimraf "^3.0.2"
-    ssri "^8.0.0"
+    ssri "^8.0.1"
     tar "^6.1.0"
 
 parse-headers@^2.0.2:
@@ -1426,6 +1406,14 @@ promise-retry@^1.1.1:
     err-code "^1.0.0"
     retry "^0.10.0"
 
+promise-retry@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-2.0.1.tgz#ff747a13620ab57ba688f5fc67855410c370da22"
+  integrity sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==
+  dependencies:
+    err-code "^2.0.2"
+    retry "^0.12.0"
+
 psl@^1.1.28:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
@@ -1453,10 +1441,10 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-read-package-json-fast@^1.1.1, read-package-json-fast@^1.1.3:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/read-package-json-fast/-/read-package-json-fast-1.2.1.tgz#e8518d6f37c99eb3afc26704c5cbb50d7ead82dd"
-  integrity sha512-OFbpwnHcv74Oa5YN5WvbOBfLw6yPmPcwvyJJw/tj9cWFBF7juQUDLDSZiOjEcgzfweWeeROOmbPpNN1qm4hcRg==
+read-package-json-fast@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/read-package-json-fast/-/read-package-json-fast-2.0.1.tgz#c767f6c634873ffb6bb73788191b65559734f555"
+  integrity sha512-bp6z0tdgLy9KzdfENDIw/53HWAolOVoQTRWXv7PUiqAo3YvvoUVeLr7RWPWq+mu7KUOu9kiT4DvxhUgNUBsvug==
   dependencies:
     json-parse-even-better-errors "^2.3.0"
     npm-normalize-package-bin "^1.0.1"
@@ -1473,16 +1461,6 @@ readable-stream@^2.0.6:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
-
-readdir-scoped-modules@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz#8d45407b4f870a0dcaebc0e28670d18e74514309"
-  integrity sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==
-  dependencies:
-    debuglog "^1.0.1"
-    dezalgo "^1.0.0"
-    graceful-fs "^4.1.2"
-    once "^1.3.0"
 
 regenerator-runtime@^0.13.4:
   version "0.13.7"
@@ -1535,6 +1513,11 @@ retry@^0.10.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
+
 rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -1586,10 +1569,10 @@ rollup-plugin-typescript2@0.29.0:
     resolve "1.17.0"
     tslib "2.0.1"
 
-rollup@2.38.4:
-  version "2.38.4"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.38.4.tgz#1b84ea8728c73b1a00a6a6e9c630ec8c3fe48cea"
-  integrity sha512-B0LcJhjiwKkTl79aGVF/u5KdzsH8IylVfV56Ut6c9ouWLJcUK17T83aZBetNYSnZtXf2OHD4+2PbmRW+Fp5ulg==
+rollup@2.38.5:
+  version "2.38.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.38.5.tgz#be41ad4fe0c103a8794377afceb5f22b8f603d6a"
+  integrity sha512-VoWt8DysFGDVRGWuHTqZzT02J0ASgjVq/hPs9QcBOGMd7B+jfTr/iqMVEyOi901rE3xq+Deq66GzIT1yt7sGwQ==
   optionalDependencies:
     fsevents "~2.3.1"
 
@@ -1704,7 +1687,7 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-ssri@^8.0.0:
+ssri@^8.0.0, ssri@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af"
   integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==


### PR DESCRIPTION
As a point of optimization; there are scenarios where a consumer may want all payloads found in a chunk. Currently it'll yield synchronously, however there is a process tick in-between. This PR aims to resolve that by optionally yielding an array of payloads found in the incoming chunk.

```js
const chunks = await fetch('/fetch-multipart')
	.then(r => meros(r, {multiple: true}));

for await (const parts of chunks) {
	parts.forEach(part => {
		// do something with this part
	})
}
``` 

cc @acao @robrichard