### PR TITLE
fix: allow boundary characters exist in the payloads

### DIFF
--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -17,7 +17,6 @@ export async function* generate<T>(
 		is_preamble = true,
 		payloads = [];
 
-
 	outer: for await (const chunk of stream) {
 		let idx_boundary = buffer.byteLength;
 		buffer = Buffer.concat([buffer, chunk]);

--- a/test/meros.spec.ts
+++ b/test/meros.spec.ts
@@ -373,6 +373,83 @@ bar
 `,
 			]);
 		});
+
+		t('should allow boundary char in payload', async () => {
+			const {
+				asyncIterableIterator,
+				pushValue,
+			} = makePushPullAsyncIterableIterator();
+			const response = await responder(asyncIterableIterator, '-');
+
+			const parts = await meros(response);
+			const collection = [];
+
+			pushValue([
+				preamble,
+				wrap,
+				makePart({ 'desc': '---' }),
+				tail,
+			]);
+
+			for await (let { body: part } of parts) {
+				collection.push(Buffer.isBuffer(part) ? part.toString() : part);
+			}
+
+			assert.equal(collection, [{ 'desc': '---' }]);
+		});
+
+		t('should allow boundary char in in multiple chunks', async () => {
+			const {
+				asyncIterableIterator,
+				pushValue,
+			} = makePushPullAsyncIterableIterator();
+			const response = await responder(asyncIterableIterator, '-');
+
+			const parts = await meros(response);
+			const collection = [];
+
+			pushValue([
+				preamble,
+				wrap,
+				makePart({ 'one': '---' }),
+			]);
+
+			pushValue([
+				wrap,
+				makePart({ 'two': '---' }),
+				tail
+			]);
+
+			for await (let { body: part } of parts) {
+				collection.push(Buffer.isBuffer(part) ? part.toString() : part);
+			}
+
+			assert.equal(collection, [{ 'one': '---' }, { 'two': '---' }]);
+		});
+
+		t('should allow simple boundary char payload', async () => {
+			const {
+				asyncIterableIterator,
+				pushValue,
+			} = makePushPullAsyncIterableIterator();
+			const response = await responder(asyncIterableIterator, '-');
+
+			const parts = await meros(response);
+			const collection = [];
+
+			pushValue([
+				preamble,
+				wrap,
+				makePart('"---"'),
+				tail
+			]);
+
+			for await (let { body: part } of parts) {
+				collection.push(Buffer.isBuffer(part) ? part.toString() : part);
+			}
+
+			assert.equal(collection, ['"---"']);
+		});
 	});
 
 	describe('boundary', (t) => {

--- a/test/meros.spec.ts
+++ b/test/meros.spec.ts
@@ -178,7 +178,7 @@ function testFor(
 
 			assert.equal(collection, [
 				{
-					'content-type': 'application/json',
+					'content-type': 'application/json; charset=utf-8',
 					'cache-control': 'public,max-age=30',
 					'etag': 'test',
 					'x-test': 'test:test',
@@ -263,7 +263,7 @@ function testFor(
 			assert.equal(value, [
 				{
 					headers: {
-						'content-type': 'application/json',
+						'content-type': 'application/json; charset=utf-8',
 					},
 					body: { foo: 'bar' },
 					json: true,
@@ -417,7 +417,7 @@ bar
 			pushValue([
 				wrap,
 				makePart({ 'two': '---' }),
-				tail
+				tail,
 			]);
 
 			for await (let { body: part } of parts) {
@@ -441,7 +441,7 @@ bar
 				preamble,
 				wrap,
 				makePart('"---"'),
-				tail
+				tail,
 			]);
 
 			for await (let { body: part } of parts) {
@@ -449,6 +449,76 @@ bar
 			}
 
 			assert.equal(collection, ['"---"']);
+		});
+
+		t('should allow real-world dataset', async () => {
+			const {
+				asyncIterableIterator,
+				pushValue,
+			} = makePushPullAsyncIterableIterator();
+			const response = await responder(asyncIterableIterator, '-');
+
+			const parts = await meros(response);
+			const collection = [];
+
+			pushValue([
+				wrap,
+				makePart({
+					'data': { 'user': { 'id': 'VXNlcgpkN2FhNzFjMjctN2I0Yy00MzczLTkwZGItMzhjMjZlNjA4MzNh' } },
+					'hasNext': true,
+				}),
+				wrap,
+				...splitString(makePart({
+					'label': 'WelcomeQuery$defer$ProjectList_projects_1qwc77',
+					'path': ['user'],
+					'data': {
+						'id': 'VXNlcgpkN2FhNzFjMjctN2I0Yy00MzczLTkwZGItMzhjMjZlNjA4MzNh',
+						'projects': {
+							'edges': [{
+								'node': {
+									'id': 'UHJvamVjdAppMQ==',
+									'name': 'New project',
+									'desc': '',
+									'lastUpdate': '2021-12-22T12:57:45.488\u002B03:00',
+									'__typename': 'Project',
+								}, 'cursor': 'MA==',
+							}], 'pageInfo': { 'endCursor': 'MA==', 'hasNextPage': false },
+						},
+					},
+					'hasNext': false,
+				}), 11),
+				tail,
+			]);
+
+			for await (let { body: part } of parts) {
+				collection.push(Buffer.isBuffer(part) ? part.toString() : part);
+			}
+
+			assert.equal(collection, [
+				{
+					'data': { 'user': { 'id': 'VXNlcgpkN2FhNzFjMjctN2I0Yy00MzczLTkwZGItMzhjMjZlNjA4MzNh' } },
+					'hasNext': true,
+				},
+				{
+					'label': 'WelcomeQuery$defer$ProjectList_projects_1qwc77',
+					'path': ['user'],
+					'data': {
+						'id': 'VXNlcgpkN2FhNzFjMjctN2I0Yy00MzczLTkwZGItMzhjMjZlNjA4MzNh',
+						'projects': {
+							'edges': [{
+								'node': {
+									'id': 'UHJvamVjdAppMQ==',
+									'name': 'New project',
+									'desc': '',
+									'lastUpdate': '2021-12-22T12:57:45.488\u002B03:00',
+									'__typename': 'Project',
+								}, 'cursor': 'MA==',
+							}], 'pageInfo': { 'endCursor': 'MA==', 'hasNextPage': false },
+						},
+					},
+					'hasNext': false,
+				},
+			]);
 		});
 	});
 

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -11,7 +11,7 @@ export const preamble = () => 'preamble';
 export const makePart = (payload: any, headers: string = []): Part => {
 	const returns = [
 		`content-type: ${
-			typeof payload === 'string' ? 'text/plain' : 'application/json'
+			typeof payload === 'string' ? 'text/plain' : 'application/json; charset=utf-8'
 		}`,
 		...headers,
 		'',


### PR DESCRIPTION
The rationale is that before we were peeking at `---` (or the boundary), and finding the last occurrence of this in the string "from start to finish".

But we know full well the boundary will ONLY exist when prefixed with a `\r\n`, so change 1 is about peeking for `\r\n + boundary`.

Then we had the issue that we were searching the entire chunk for this symbol, which never matches (with our cross chunk strategy), so now we purely look from the headers to the end of the string, and if not found then return the entire rest of the payload.

resolves #13